### PR TITLE
Fix error related to missing messageid

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1336,6 +1336,7 @@ async def agent_status():
         messageid = int(subject["message"])
     else:
         channelid = DISCORD_AGENT_STATS
+        messageid = DISCORD_AGENT_STATS_MSG
 
     channel = bot.get_channel(channelid)
     table = Texttable(160)


### PR DESCRIPTION
Was getting this error with bot.py before putting this fix in. Afterwards the bot worked as expected.

```
Jul 02 20:23:01 MLDevBasic bash[600608]:   File "/opt/dd-discord-bot/bot.py", line 197, in task_loop
Jul 02 20:23:01 MLDevBasic bash[600608]:     await agent_status()
Jul 02 20:23:01 MLDevBasic bash[600608]:   File "/opt/dd-discord-bot/bot.py", line 1379, in agent_status
Jul 02 20:23:01 MLDevBasic bash[600608]:     if messageid != None:
Jul 02 20:23:01 MLDevBasic bash[600608]: UnboundLocalError: local variable 'messageid' referenced before assignment
```